### PR TITLE
Adding support for highlighting permanent hazards

### DIFF
--- a/WME-Color-Highlights.user.js
+++ b/WME-Color-Highlights.user.js
@@ -1149,6 +1149,16 @@ function updateUserList() {
             editorNames.push(editedBy);
         }
     }
+    // collect array of users who have edited permanent hazards
+    for (const hazard of getAllPermanentHazards()) {
+        editedBy = hazard.modificationData.createdBy;
+        if (hazard.modificationData.updatedBy) {
+            editedBy = hazard.modificationData.updatedBy;
+        }
+        if (editorNames.indexOf(editedBy) == -1) {
+            editorNames.push(editedBy);
+        }
+    }
     if (editorNames.length === 0) {
         return;
     }

--- a/WME-Color-Highlights.user.js
+++ b/WME-Color-Highlights.user.js
@@ -1477,7 +1477,7 @@ async function initialiseHighlights() {
         highlightSegments(e);
     };
 
-    getId('_numRecentDays').onchange = highlightSegmentsAndPlaces;
+    getId('_numRecentDays').onchange = createHighlightMultipleLayers(true, true, true);
     getId('_numRecentDays').onclick = function (e) {
         getId('_cbHighlightRecent').checked = 1;
         createHighlightMultipleLayers(true, true, true)(e);

--- a/WME-Color-Highlights.user.js
+++ b/WME-Color-Highlights.user.js
@@ -19,7 +19,6 @@ const PERMANENT_HAZARDS_HIGHLIGHTING_LAYER = 'color_highlights_permanent_hazards
 window.SDK_INITIALIZED.then(() => {
     wmeSDK = getWmeSdk({scriptId: "wme-color-highlights", scriptName: "WME Color Highlights"});
     wmeSDK.Events.once({eventName: "wme-ready"}).then(initialiseHighlights);
-    initPermanentHazardsLayer();
 });
 
 function catchError(fn, errorsToCatch = []) {
@@ -1353,6 +1352,8 @@ function initVenueMainCategories() {
 /* =========================================================================== */
 async function initialiseHighlights() {
     console.group("WME Color Highlights: " + wmech_version);
+
+    initPermanentHazardsLayer();
 
     const scriptTab = await wmeSDK.Sidebar.registerScriptTab();
 

--- a/WME-Color-Highlights.user.js
+++ b/WME-Color-Highlights.user.js
@@ -195,6 +195,8 @@ function initPermanentHazardsLayer() {
     if (addLayerFailed) return;
 
     const addPermanentHazard = (hazard) => {
+        if (!hazard) throw new Error('Permanent hazard is undefined');
+
         wmeSDK.Map.addFeatureToLayer({
             layerName: PERMANENT_HAZARDS_HIGHLIGHTING_LAYER,
             feature: {

--- a/WME-Color-Highlights.user.js
+++ b/WME-Color-Highlights.user.js
@@ -167,7 +167,7 @@ function trackDataModelEvents(dataModelName, featureMapper, {
  * Get the display geometry for a feature by searching through the provided layers.
  * Can be used to get the geometry as rendered on the map, which may differ from the data model geometry.
  * @param {number|string} objectId The object ID of the feature
- * @param {OpenLayers.Layer} sourceLayers The layers to search through
+ * @param {OpenLayers.Layer[]} sourceLayers The layers to search through
  * @returns {object} The GeoJSON geometry of the feature as it is rendered on the map (not necessarily the same as the data model geometry)
  * @throws {Error} If the feature is not found in any of the provided layers
  */

--- a/WME-Color-Highlights.user.js
+++ b/WME-Color-Highlights.user.js
@@ -110,7 +110,7 @@ function trackDataModelEvents(dataModelName, featureMapper, {
             // ideally, the WME SDK should not throw ValidationError here, but if it does,
             // then we're dealing with a data model that does not support native event tracking through the SDK
             // which is a shame, due to how generic the data model event tracking mechanism is
-            // so we'll have to resort to manually hatching the underlying WME events and match the SDK safety guards
+            // so we'll have to resort to manually hooking the underlying WME events and match the SDK safety guards
 
             if (wmeSDK.Events.trackedDataModels.has(dataModelName)) return;
 

--- a/WME-Color-Highlights.user.js
+++ b/WME-Color-Highlights.user.js
@@ -172,6 +172,8 @@ function getPermanentHazardDisplayGeometry(objectId) {
         const openLayersGeometry = feature.geometry;
         return W.userscripts.toGeoJSONGeometry(openLayersGeometry);
     }
+
+    throw new Error(`Permanent hazard geometry not found: ${objectId}`);
 }
 
 function initPermanentHazardsLayer() {

--- a/WME-Color-Highlights.user.js
+++ b/WME-Color-Highlights.user.js
@@ -1041,7 +1041,7 @@ function highlightPermanentHazards(event) {
     })();
 
 
-    for (var hazard of getAllPermanentHazards()) {
+    for (const hazard of getAllPermanentHazards()) {
         const symbol = wmeSDK.Map.getFeatureDomElement({featureId: hazard.id, layerName: PERMANENT_HAZARDS_HIGHLIGHTING_LAYER});
         if (!symbol) continue;
 

--- a/WME-Color-Highlights.user.js
+++ b/WME-Color-Highlights.user.js
@@ -52,7 +52,7 @@ function trackDataModelEvents(dataModelName, featureMapper, {
         wmeSDK.Events.on({
             eventName: 'wme-data-model-object-changed-id',
             eventHandler: createHandler(({ objectIds }) => {
-                if (removed) removed(featureMapper(objectIds.oldID));
+                if (removed) removed(objectIds.oldID);
                 if (added) added(featureMapper(objectIds.newID));
             }),
         });

--- a/WME-Color-Highlights.user.js
+++ b/WME-Color-Highlights.user.js
@@ -1433,7 +1433,8 @@ async function initialiseHighlights() {
             <label title="Highlight Permanent Hazards edited recently or by selected editor">
                 <input type="checkbox" id="_cbHighlightPermanentHazards" />
                 <b>Highlight Permanent Hazards</b>
-            </label>
+            </label><br>
+            <i style="padding-left: 20px">Show recent edits or last editor</i>
         `;
     section.appendChild(highlightHazardsSection);
 

--- a/WME-Color-Highlights.user.js
+++ b/WME-Color-Highlights.user.js
@@ -1047,7 +1047,7 @@ function highlightPermanentHazards(event) {
 
         const newFill = shouldHighlightAsEdited(hazard) ? '#0f0' : null;
 
-        if (newFill) {;
+        if (newFill) symbol.setAttribute("fill", newFill);
     }
 }
 

--- a/WME-Color-Highlights.user.js
+++ b/WME-Color-Highlights.user.js
@@ -44,7 +44,7 @@ function trackDataModelEvents(dataModelName, featureMapper, {
             if (dataModelName !== eventDataModelName) return;
             handler(args);
         }
-    }
+    };
 
     let hasSubscribedEvents = false;
     if (added || removed) {

--- a/WME-Color-Highlights.user.js
+++ b/WME-Color-Highlights.user.js
@@ -1523,7 +1523,7 @@ async function initialiseHighlights() {
         getId('_cbHighlightEditor').checked = options[13];
         getId('_cbHighlightRoutingPref').checked = options[25];
 
-        getId('_cbHighlightPermanentHazards').checked = options[30];
+        getId('_cbHighlightPermanentHazards').checked = options[30] ?? false;
     }
     else {
         getId('_cbHighlightPlaces').checked = true;

--- a/WME-Color-Highlights.user.js
+++ b/WME-Color-Highlights.user.js
@@ -1057,9 +1057,9 @@ function highlightPermanentHazards(event) {
         const symbol = wmeSDK.Map.getFeatureDomElement({featureId: hazard.id, layerName: PERMANENT_HAZARDS_HIGHLIGHTING_LAYER});
         if (!symbol) continue;
 
-        const newFill = shouldHighlightAsEdited(hazard) ? '#0f0' : null;
+        const newFill = shouldHighlightAsEdited(hazard) ? '#0f0' : 'transparent';
 
-        if (newFill) symbol.setAttribute("fill", newFill);
+        symbol.setAttribute("fill", newFill);
     }
 }
 


### PR DESCRIPTION
# Description

This pull request introduces support for highlighting **Permanent Hazards** (PH) based on recent edits and/or specific editors. 

Previously, WME Color Highlights focused primarily on segments and venues (places). Extending this functionality to permanent hazards provides editors with essential visual feedback for auditing and tracking hazard-related changes, which are often more difficult to distinguish than standard geometry.

# Key Changes

### 1. Unified Layer Management
I have introduced a new utility to streamline complex layer updates while maintaining a clear separation of concerns.
* **New Function:** `createHighlightMultipleLayers` has been implemented to handle event listeners for checkboxes that require simultaneous updates across multiple layers.
* **Scope of Change:** **Within the codebase and this pull request**, this function is not applied to all checkboxes. It is used exclusively for checkboxes that trigger updates to the Permanent Hazard layer. While the function is architecturally capable of handling all other checkboxes as well, I have opted to keep them separate to avoid unnecessary refactors and to maintain a strict separation of concerns.

### 2. Implementation: The Proxy Vector Layer
Permanent hazards present a unique challenge because they are often distributed across multiple map layers and rendered as rasterized graphics. Unlike vectorized segments or venues, their DOM elements cannot be directly styled via CSS.

* **Custom Vector Overlay:** The script now generates a dedicated vector layer that mirrors permanent hazard features as `Point` or `Polygon` geometries.
* **Visual Styling:** By mapping hazards to this new layer, we can apply the same highlighting logic (e.g., updating the `fill` attribute) used for other map features.
* **Geometry Accuracy:** To ensure visual alignment, geometries are extracted from the underlying OpenLayers map features rather than the raw data model. This prevents "snapping" issues where a marker's visual position (e.g., a traffic light offset from a junction) differs from its logical coordinates in the data model.

### 3. Bridging SDK Limitations
The current WME SDK does not fully support permanent hazard interactions. To maintain a consistent developer experience while working around these limitations, I've implemented the following:

* **`trackDataModelEvents` Wrapper:** This utility allows for subscribing to multiple data model events in a single call. It handles standard SDK tracking but falls back to raw data model repository subscriptions for hazards, ensuring the custom layer remains in sync with map changes.
* **`getAllPermanentHazards` Helper:** This function simulates the expected future SDK interface for hazards. It provides a minimal, clean API for identifying and filtering hazards for highlighting purposes.

### 4. Storage and Configuration
* New options for permanent hazards have been added to `localStorage`.
* Settings are persisted and loaded alongside existing highlight configurations.

# How to Test

1.  **Load the Script:** Load the updated userscript in the Waze Map Editor.
2.  **Toggle Settings:** Open the WME Color Highlights settings panel and locate the new Permanent Hazard options.
3.  **Highlight Verification:**
    * Identify a permanent hazard that has been edited recently.
    * Enable the highlight and verify that the hazard is overlaid with the correct color (point or polygon).
5.  **Alignment Check:** Zoom in and out or pan the map. Ensure the vector highlight remains perfectly aligned with the underlying hazard marker.
6.  **Persistence:** Change the PH highlight settings, refresh the page, and confirm the settings were saved.
7.  **Regression Check:** Toggle standard segment and place highlights. Confirm that their behavior remains unaffected by the new `createHighlightMultipleLayers` logic.

---

# Additional Notes
* **Version Bump:** The script version has not been incremented in this PR. Please create a follow-up commit to bump the version if required during the merge.