### PR TITLE
fix: add line break to highlight places section

### DIFF
--- a/WME-Color-Highlights.user.js
+++ b/WME-Color-Highlights.user.js
@@ -1105,7 +1105,7 @@ async function initialiseHighlights() {
     highlightPlacesSection.innerHTML = `
             <label title="parks/trees = green, water = blue, parking lot = cyan, everything else = pink">
                 <input type="checkbox" id="_cbHighlightPlaces" /><b>Highlight Places</b>*
-            </label>
+            </label><br />
             <label><input type="checkbox" id="_cbHighlightLockedPlaces" /> Locked Places* (Red)</label><br>
             <label title="If blank name or street, or wrong category"><input type="checkbox" id="_cbHighlightIncompletePlaces" /> Incomplete Places (Dashed Orange)</label><br>
         `;


### PR DESCRIPTION
This line break was missed during a previous refactor. It caused the "Highlight places" master checkbox to be on the same line as the "Highlight locked places" configuration checkbox.

This commit restores the missing line break, thereby restoring the natural flow.

It has also been mentioned in #4 by @MrTimbones during pull request review, and was pointed out in https://github.com/MrTimbones/WME-Color-Highlights/pull/4#discussion_r2749744915.